### PR TITLE
fix: prevent blocks from being outdented past zoom root in focused view

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -1765,12 +1765,21 @@
 (defn on-tab
   "`direction` = :left | :right."
   [direction]
-  (let [blocks (get-selected-ordered-blocks)]
+  (let [blocks (get-selected-ordered-blocks)
+        indent? (= direction :right)
+        page (state/get-current-page)
+        zoom-root (when (and (not indent?) page (util/uuid-string? page))
+                    (db/entity [:block/uuid (parse-uuid page)]))
+        blocks (if zoom-root
+                 (remove (fn [b]
+                           (= (:db/id (:block/parent b)) (:db/id zoom-root)))
+                         blocks)
+                 blocks)]
     (when (seq blocks)
       (outliner-tx/transact!
        {:outliner-op :move-blocks
         :real-outliner-op :indent-outdent}
-       (outliner-core/indent-outdent-blocks! blocks (= direction :right))))))
+       (outliner-core/indent-outdent-blocks! blocks indent?)))))
 
 (defn- get-link [format link label]
   (let [link (or link "")
@@ -2820,16 +2829,23 @@
   (let [pos (some-> (state/get-input) cursor/pos)
         {:keys [block]} (get-state)]
     (when block
-      (state/set-editor-last-pos! pos)
-      (outliner-tx/transact!
-       {:outliner-op :move-blocks
-        :real-outliner-op :indent-outdent}
-       (outliner-core/indent-outdent-blocks! [block] indent?))
-      (edit-block!
-       (db/pull (:db/id block))
-       (cursor/pos (state/get-input))
-       (:block/uuid block)))
-    (state/set-editor-op! :nil)))
+      (let [outdent-past-zoom-root? (when-not indent?
+                                      (let [page (state/get-current-page)]
+                                        (and page
+                                             (util/uuid-string? page)
+                                             (let [zoom-root (db/entity [:block/uuid (parse-uuid page)])]
+                                               (= (:db/id (:block/parent block)) (:db/id zoom-root))))))]
+        (when-not outdent-past-zoom-root?
+          (state/set-editor-last-pos! pos)
+          (outliner-tx/transact!
+           {:outliner-op :move-blocks
+            :real-outliner-op :indent-outdent}
+           (outliner-core/indent-outdent-blocks! [block] indent?))
+          (edit-block!
+           (db/pull (:db/id block))
+           (cursor/pos (state/get-input))
+           (:block/uuid block))))))
+  (state/set-editor-op! :nil))
 
 (defn keydown-tab-handler
   [direction]


### PR DESCRIPTION
Fixes #24

## Summary

When outdenting a block whose parent is the zoom root in focused view, the block would disappear. This adds a guard to skip outdent for blocks that are direct children of the zoom root, in both `on-tab` (Tab/Shift-Tab) and `indent-outdent-aux!` (keyboard shortcut) handlers.

## Changes

- **`on-tab`**: When outdenting, filter out blocks whose parent is the zoom root before performing the operation
- **`indent-outdent-aux!`**: Skip the outdent operation entirely when the block's parent is the zoom root

Same fix as https://github.com/logseq/logseq/pull/12583 in the DB version.

## Test plan

- [ ] Open a page with nested blocks
- [ ] Zoom into a block
- [ ] Select a direct child of the zoom root
- [ ] Press Shift+Tab — block should NOT be outdented
- [ ] Press Tab — block should still indent normally
- [ ] Select a deeper nested block and press Shift+Tab — should outdent normally (one level at a time)