### PR TITLE
chore: Add an explanatory note about the OG split to top of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+
+> [!IMPORTANT]  
+> **Why this repository?**  
+> As of 2.0, [`logseq/logseq`](https://github.com/logseq/logseq) has switched from using markdown files on disk to using a graph database.
+>
+> Logseq OG (this repo) maintains the prior file-based approach. You can find more details [here](https://logseq.io/p/e3YDyX5AYr)
+
+
 <!-- logo -->
 <p align="center">
     <a href="https://logseq.com" alt="Logseq Logo">


### PR DESCRIPTION
I became aware of the split here by virtue of my `brew update` producing:

```
…
==> Downloading https://formulae.brew.sh/api/cask.jws.json
aphera: Raw photo editing software
logseq-og: Privacy-first, open-source platform for knowledge sharing and management
…
```

and was curious enough to run `brew home logseq-og` and end up here. While I did see the "(file based)" in this repo's description, as someone who hasn't been following dev of Logseq, I was unable to answer my immediate question of "As opposed to what?" in my first 3 attempts of:

1. looking at the README of this repo
2. navigating over to the other version's repo & looking at its description and README
3. looking at this repo's most recent release

(while I would have succeeded if I'd gone perhaps one further and looked at _that_ repo's [newest release](https://github.com/logseq/logseq/releases/tag/2.0.1), I in fact switched over to the different tact of seeing what the person who had contributed the formula/cask [had said](https://github.com/Homebrew/homebrew-cask/commit/6f79baae75df583169c75344d866282ea76b4046) )

I think it is appropriate to include an easily locatable explanation to answer this question.

I was feeling generous this afternoon to jump through the various hoops to offer this PR (as my first contribution to Logseq) as one such option

--- 

Feel free to change the format of the callout to `[!NOTE]`, etc. if you think it a better fit, etc.