### PR TITLE
fix(electron): never let a failed graph save make the window unclosable

### DIFF
--- a/src/electron/electron/handler.cljs
+++ b/src/electron/electron/handler.cljs
@@ -304,6 +304,15 @@
   (async/put! state/persistent-dbs-chan true)
   true)
 
+;; The renderer sends this when frontend.db/persist! rejected. Without a method here
+;; it fell through to :default, electron.window/close-handler stayed parked on
+;; persistent-dbs-chan forever, and the window could never be closed again. Unblock the
+;; close: the markdown files are the source of truth, the transit file is only a cache.
+(defmethod handle :persistent-dbs-error [_window _]
+  (logger/error "Failed to persist the graph cache. Closing anyway - your files on disk are unaffected, but the next startup will re-index.")
+  (async/put! state/persistent-dbs-chan true)
+  true)
+
 ;; Search related IPCs
 (defmethod handle :search-blocks [_window [_ repo q opts]]
   (search/search-blocks repo q opts))
@@ -691,8 +700,11 @@
 (defmethod handle :cancel-all-requests [_ args]
   (apply rsapi/cancel-all-requests (rest args)))
 
-(defmethod handle :default [args]
-  (logger/error "Error: no ipc handler for:" args))
+;; `handle` is dispatched with two arguments, so a one-argument :default threw an arity
+;; exception instead of logging -- and the exception was swallowed by set-ipc-handler!,
+;; hiding the unhandled channel entirely. Log the channel name rather than the window.
+(defmethod handle :default [_window args]
+  (logger/error "Error: no ipc handler for:" (first args)))
 
 (defn broadcast-persist-graph!
   "Receive graph-name (not graph path)

--- a/src/electron/electron/window.cljs
+++ b/src/electron/electron/window.cljs
@@ -14,6 +14,12 @@
 
 (defonce *quitting? (atom false))
 
+(def ^:private persist-dbs-timeout-ms
+  "How long close-handler waits for the renderer to confirm the graph cache was saved
+  before closing the window regardless. Generous enough for a large graph to serialize,
+  short enough that a user never faces a window that simply refuses to close."
+  10000)
+
 (def MAIN_WINDOW_ENTRY (if dev?
                          ;"http://localhost:3001"
                          (str "file://" (node-path/join js/__dirname "index.html"))
@@ -89,12 +95,17 @@
     (.send web-contents "persist-zoom-level" (.getZoomLevel web-contents))
     (.send web-contents "persistent-dbs"))
   (async/go
-    (let [_ (async/<! state/persistent-dbs-chan)]
+    ;; This runs after (.preventDefault e), so the window is already committed to not
+    ;; closing on its own. A bare <! here means any renderer that never answers -- because
+    ;; the save threw, or the renderer is wedged -- leaves the window permanently
+    ;; unclosable, with no message to the user. Time the wait out and close regardless:
+    ;; the graph's files on disk are the source of truth, the transit blob is a cache.
+    (let [timeout-ch (async/timeout persist-dbs-timeout-ms)
+          [_ port]   (async/alts! [state/persistent-dbs-chan timeout-ch])]
+      (when (identical? port timeout-ch)
+        (logger/error "Timed out after" persist-dbs-timeout-ms
+                      "ms waiting for the graph cache to be saved. Closing the window anyway; the next startup will re-index."))
       (destroy-window! win)
-      ;; (if @*quitting?
-      ;;   (doseq [win (get-all-windows)]
-      ;;     (destroy-window! win))
-      ;;   (destroy-window! win))
       (when @*quitting?
         (async/put! state/persistent-dbs-chan true)))))
 


### PR DESCRIPTION
Companion to #42. That PR removes one way the graph save can fail; this one makes **any** save
failure survivable instead of turning the app into something that can never be closed.

Refs [logseq/logseq#12968](https://github.com/logseq/logseq/issues/12968).

## The bug

If `frontend.db/persist!` rejects, `frontend.handler.repo/persist-db!` catches it and calls
`on-error`, which `electron.listener/persist-dbs!` wires to `(ipc/ipc "persistent-dbs-error")`
(`src/main/electron/listener.cljs:39`).

**Nothing handles that channel.** `grep -rn "persistent-dbs-error"` over the whole tree returns
exactly one hit: the sender. Three things then go wrong at once:

**1. The close handler parks forever.** `electron.window/close-handler`
(`src/electron/electron/window.cljs:82-99`) calls `(.preventDefault e)` *first and unconditionally*,
sends `"persistent-dbs"`, then waits on a bare `(async/<! state/persistent-dbs-chan)`. That channel
is only ever fed by `:persistent-dbs-saved`, so when the renderer answers on the error channel
instead the go block waits forever and `(destroy-window! win)` is unreachable. There is no timeout.

**2. The `:default` fallback throws instead of logging.** `(defmulti handle (fn [_window args] ...))`
dispatches with two arguments, but `(defmethod handle :default [args] ...)` declares one
(`handler.cljs:694`). So an unhandled channel raises an arity exception, which `set-ipc-handler!`
swallows. The single log line it does produce prints the *BrowserWindow object* rather than the
channel name — a ~200-line object dump that identifies nothing.

**3. Retrying does nothing.** `electron/core.cljs:322-324` runs `(reset! *win nil)` right after the
first close attempt and guards the retry with `(when window ...)`. From the second click onward, X /
Quit / Ctrl+Q call `preventDefault` and then do *nothing at all* — silently.

The user-visible result is an application that ignores every quit request, with no dialog and
effectively no log trail. On macOS there is at least a transient "syncing internal status" toast; on
Linux there is no feedback whatsoever. My own instance sat like this for **2 days 16 hours**. Nothing
was deadlocked — every thread was sleeping and the renderer answered `executeJavaScript` in 2 ms.

I confirmed (3) on the stuck instance by replaying the close through the Electron main-process
inspector: `close` fired, `defaultPrevented: true`, window still alive 6 s later, **zero** renderer
errors recorded and **zero** new log lines.

## The change

- Add `:persistent-dbs-error`, which logs and unblocks the channel so the window can close.
- Give the wait a 10 s timeout, so a renderer that never answers at all (wedged, crashed) can't
  reproduce this either.
- Fix the `:default` arity and log the channel name instead of the window.

Closing without the cache is safe and worth saying explicitly: the graph's markdown files are the
source of truth and are already on disk. The `.transit` file is only a parsed-DB cache, so the cost
of closing anyway is a slower next startup, not data loss. Silently refusing to close is strictly
worse — in my case it also meant the cache silently stopped being written for **eight days** before I
noticed.

## Verification

Built this branch with the `create_page` fix from #42 **deliberately left out**, so the Bean bug is
live and the save genuinely fails, then ran it against a real 5228-page graph:

```
1. trigger the Bean : create_page('zz-prb-test', {a:'b'})  -> created 130448
2. force a persist  : bean error present: True          <- save really is failing
3. close the window : EXITED at t+1s

09:36:20.820 > Failed to persist the graph cache. Closing anyway - your files on disk are
               unaffected, but the next startup will re-index.
09:36:39.921 > window-all-closed Quitting...
```

On the unpatched build that exact sequence is the permanent hang. Here it logs a clear reason and
exits in a second.

**One caveat, stated plainly:** I did not manage to observe the 10 s timeout fire at runtime. Once
`:persistent-dbs-error` is handled it always unblocks the channel first, and I could not induce
"renderer never replies at all" from outside the app. The timeout is compiled (release build, 0
warnings) and is a standard `alts!` over `async/timeout`, but it is reviewed rather than exercised —
worth a reviewer's eye. Happy to drop it to a separate PR if you'd prefer to take only the handler
and arity fixes, which are the ones under test.
