### PR TITLE
fix(electron): make New Window work on macOS with an open graph

### DIFF
--- a/src/electron/electron/core.cljs
+++ b/src/electron/electron/core.cljs
@@ -186,7 +186,9 @@
                        {:role "fileMenu"
                         :submenu [{:label "New Window"
                                    :click (fn []
-                                            (p/let [graph-name (get-graph-name (state/get-active-window-graph-path))
+                                            (p/let [graph-name (get-graph-name
+                                                                (state/get-window-graph-path
+                                                                 (utils/get-focused-window)))
                                                     _ (handler/broadcast-persist-graph! graph-name)]
                                               (handler/open-new-window!)))
                                    :accelerator (if mac?

--- a/src/electron/electron/state.cljs
+++ b/src/electron/electron/state.cljs
@@ -46,16 +46,6 @@
   []
   (set (vals (:window/graph @state))))
 
-(defn get-active-window-graph-path
-  "Get the path of the graph of the currently focused window (might be `nil`)"
-  []
-  (let [windows (:window/graph @state)
-        active-windows-pairs (filter #(.isFocused (first %)) windows)
-        active-window-pair (first active-windows-pairs)
-        path (second active-window-pair)]
-    path)
-  )
-
 (defn close-window!
   [window]
   (swap! state medley/dissoc-in [:window/graph window]))


### PR DESCRIPTION
- fix https://github.com/logseq/logseq/issues/11090 in OG

I reproduced this on macOS (Apple Silicon) with Logseq OG 1.0.0 build 92, based on Electron 41.7.1. File → New Window and Command+N did nothing when a graph was open, while a clean profile worked.

In the optimized build, `get-active-window-graph-path` compiles the Electron `isFocused()` call as `$isFocused$()`. The resulting exception happens before graph persistence or window creation.

This change uses the existing `BrowserWindow.getFocusedWindow()` helper instead and keeps the current persist-before-open flow.

I tested it with an optimized Electron build and an isolated application profile. In that test the window count changed from 1 to 2, and the new window loaded and received focus.