### PR TITLE
fix(publishing): exclude desktop restart calls from publishing builds

### DIFF
--- a/src/main/frontend/components/assets.cljs
+++ b/src/main/frontend/components/assets.cljs
@@ -91,7 +91,8 @@
 (rum/defc restart-button
   []
   (ui/button (t :plugin/restart)
-             :on-click #(js/logseq.api.relaunch)
+             :on-click #(when-not config/publishing?
+                          (js/logseq.api.relaunch))
              :small? true :intent "logseq"))
 
 (rum/defcs ^:large-vars/data-var alias-directories
@@ -215,7 +216,8 @@
              #(state/set-assets-alias-enabled! (not alias-enabled?))
              true)]
       [:span
-       (when alias-enabled-changed? (restart-button))]]
+       (when (and (not config/publishing?) alias-enabled-changed?)
+         (restart-button))]]
 
      (when alias-enabled?
        [:div.pt-4

--- a/src/main/frontend/components/settings.cljs
+++ b/src/main/frontend/components/settings.cljs
@@ -233,8 +233,9 @@
          (fn []
            (state/set-state! [:electron/user-cfgs :spell-check] (not enabled?))
            (p/then (ipc/ipc :userAppCfgs :spell-check (not enabled?))
-                   #(when (js/confirm (t :relaunch-confirm-to-work))
-                      (js/logseq.api.relaunch))))
+                   #(when-not config/publishing?
+                      (when (js/confirm (t :relaunch-confirm-to-work))
+                        (js/logseq.api.relaunch)))))
          true)]]]))
 
 (rum/defcs switch-git-auto-commit-row < rum/reactive
@@ -608,7 +609,8 @@
      (ui/toggle on? on-toggle true)
      (when (not= (boolean value) on?)
        (ui/button (t :plugin/restart)
-                  :on-click #(js/logseq.api.relaunch)
+                  :on-click #(when-not config/publishing?
+                               (js/logseq.api.relaunch))
                   :small? true :intent "logseq"))]))
 
 (rum/defc http-server-enabled-switcher
@@ -622,7 +624,8 @@
      (ui/toggle on? on-toggle true)
      (when (not= (boolean value) on?)
        (ui/button (t :plugin/restart)
-                  :on-click #(js/logseq.api.relaunch)
+                  :on-click #(when-not config/publishing?
+                               (js/logseq.api.relaunch))
                   :small? true :intent "logseq"))]))
 
 (rum/defc flashcards-enabled-switcher
@@ -696,10 +699,11 @@
      "native-titlebar"
      (t :settings-page/native-titlebar)
      enabled?
-     #(when (js/confirm (t :relaunch-confirm-to-work))
-        (state/set-state! [:electron/user-cfgs :window/native-titlebar?] (not enabled?))
-        (ipc/ipc :userAppCfgs :window/native-titlebar? (not enabled?))
-        (js/logseq.api.relaunch))
+     #(when-not config/publishing?
+        (when (js/confirm (t :relaunch-confirm-to-work))
+          (state/set-state! [:electron/user-cfgs :window/native-titlebar?] (not enabled?))
+          (ipc/ipc :userAppCfgs :window/native-titlebar? (not enabled?))
+          (js/logseq.api.relaunch)))
      [:span.text-sm.opacity-50 (t :settings-page/native-titlebar-desc)])))
 
 (rum/defcs settings-general < rum/reactive
@@ -714,7 +718,8 @@
      (version-row t version)
      (language-row t preferred-language)
      (theme-modes-row t switch-theme system-theme? dark?)
-     (when (and (util/electron?) (not util/mac?)) (native-titlebar-row t))
+     (when (and (not config/publishing?) (util/electron?) (not util/mac?))
+       (native-titlebar-row t))
      (when show-radix-themes? (accent-color-row false))
      (when (config/global-config-enabled?) (edit-global-config-edn))
      (when current-repo (edit-config-edn))
@@ -744,7 +749,8 @@
      ;; (enable-block-timestamps-row t enable-block-timestamps?)
      (show-brackets-row t show-brackets?)
 
-     (when (util/electron?) (switch-spell-check-row t))
+     (when (and (not config/publishing?) (util/electron?))
+       (switch-spell-check-row t))
      (outdenting-row t logical-outdenting?)
      (showing-full-blocks t show-full-blocks?)
      (preferred-pasting-file t preferred-pasting-file?)
@@ -1055,9 +1061,9 @@
                              (when (= "Enter" (util/ekey e))
                                (update-home-page e)))}]]]])
      (whiteboards-switcher-row enable-whiteboards?)
-     (when (and (util/electron?) config/feature-plugin-system-on?)
+     (when (and (not config/publishing?) (util/electron?) config/feature-plugin-system-on?)
        (plugin-system-switcher-row))
-     (when (util/electron?)
+     (when (and (not config/publishing?) (util/electron?))
        (http-server-switcher-row))
      (flashcards-switcher-row enable-flashcards?)
      (zotero-settings-row)


### PR DESCRIPTION
I found this while auditing the optimized publishing bundle from the current `version/file` branch on macOS (Apple Silicon).

The publishing bundle contains calls compiled as `$logseq$$.api.$relaunch$()`, but that build does not include the desktop `logseq.api` implementation. The desktop bundle includes and exports `logseq.api.relaunch` as expected.

Most of the affected controls are already hidden by runtime Electron checks, so I did not reproduce this through the normal publishing UI. However, `/settings` is still part of the publishing build, and the invalid API references remain in the generated artifact.

This change adds publishing guards to the five restart actions and their render sites. It keeps the settings route and the existing desktop behavior unchanged.

I tested optimized publishing and desktop builds with Node 18. In the generated artifacts, the publishing bundle no longer contains `.$relaunch$()` or `logseq.api` references, while the desktop bundle still exports and calls `logseq.api.relaunch`.