### PR TITLE
fix: use OG release feed for updates

### DIFF
--- a/src/electron/electron/core.cljs
+++ b/src/electron/electron/core.cljs
@@ -42,7 +42,7 @@
 (defn setup-updater! [^js win]
   ;; manual/auto updater
   (when-not linux?
-    (init-updater {:repo   "logseq/logseq"
+    (init-updater {:repo   "logseq/og"
                    :win    win})))
 
 (defn open-url-handler


### PR DESCRIPTION
## Summary

Configure the desktop updater to query `logseq/og` rather than `logseq/logseq`.

The existing configuration causes Logseq OG 1.0.0 to see Logseq DB 2.x releases as available updates.

## Verification

- Confirmed the `logseq/logseq` update endpoint offers Logseq DB 2.0.1 to an OG 1.0.0 client.
- Confirmed the `logseq/og` endpoint reports no newer update for OG 1.0.0.
- Ran `git diff --check`.
- Clojure lint/tests were not run because `clojure` is unavailable in the local environment.

Fixes #37