### PR TITLE
fix: allow mobile release scripts to sync Capacitor

### DIFF
--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -1,7 +1,7 @@
 import { CapacitorConfig } from '@capacitor/cli'
 import fs from 'fs'
 
-const version = fs.readFileSync('static/package.json', 'utf8').match(/"version": "(.*?)"/)?.at(1) ?? '0.0.0'
+const version = fs.readFileSync('src/main/frontend/version.cljs', 'utf8').match(/defonce version "(.*?)"/)?.at(1) ?? '0.0.0'
 
 const config: CapacitorConfig = {
   appId: 'com.logseq.og',


### PR DESCRIPTION
## Summary

Read the mobile app version from `src/main/frontend/version.cljs` instead of the generated `static/package.json`.

The Android and iOS release scripts move `static/` into `public/` before Capacitor loads `capacitor.config.ts`. Reading the canonical source version keeps the configuration available throughout that release sequence and matches the version source updated by the release workflows.

## Verification

Tested with `static/package.json` absent, matching the reported failure state:

- Confirmed the original configuration fails during `npx cap sync android` with `ENOENT: no such file or directory, open 'static/package.json'`.
- Confirmed the fixed configuration completes `npx cap sync android` successfully.
- Confirmed `npx cap sync ios` parses the configuration and copies assets successfully; native dependency installation could not complete because this Mac does not have CocoaPods or full Xcode installed.
- Confirmed `capacitor.config.ts` passes TypeScript compilation.
- Ran `git diff --check`.

Fixes #15